### PR TITLE
FIX: comment path

### DIFF
--- a/Examples/example_clustering.py
+++ b/Examples/example_clustering.py
@@ -16,7 +16,7 @@ import pandas as pd
 import numpy as np
 
 from config_clustering import fn, ap, doi
-os.chdir('/home/arsii/tscfat')
+#os.chdir('/home/arsii/tscfat')
 
 from tscfat.Analysis.cluster_timeseries import cluster_timeseries
 from tscfat.Utils.doi2int import doi2index


### PR DESCRIPTION
Comment the path to change the directory because it does not exist in other machines. This fixes an error when running the clustering example. Probably more instructions should be given (like, add the git directory to a path).